### PR TITLE
Make interpreter styling respect light/dark mode, add styles/settings reducers, allow clicking play to restart game

### DIFF
--- a/src/common/random.ts
+++ b/src/common/random.ts
@@ -18,12 +18,17 @@ export class Random {
   mti = Random.N + 1;
   /* mti==N+1 means mt[N] is not initialized */
 
+  /** The seed used when constructing the RNG. Read only. */
+  public readonly seed: number | null = null;
+
   constructor(seed: number | null = null) {
     if (seed == null) {
-      seed = new Date().getTime();
+      this.seed = new Date().getTime();
+    } else {
+      this.seed = seed;
     }
 
-    this.init_genrand(seed);
+    this.init_genrand(this.seed);
   }
 
   private init_genrand(s: number) {

--- a/src/common/redux/authorStorySettings.actions.ts
+++ b/src/common/redux/authorStorySettings.actions.ts
@@ -1,5 +1,11 @@
 import { getActionGuid } from "./reduxTools";
-import { IRunnerLogSeparatorStyle, IRunnerStyle, IRunnerOptions, ITextStyle } from "./typedefs";
+import {
+  IRunnerLogSeparatorStyle,
+  IRunnerStyle,
+  IAuthorRunnerOptions,
+  ITextStyle,
+  IAuthorRunnerStrings,
+} from "./typedefs";
 
 export const actions = {
   setAuthorStoryInputStyles: getActionGuid(),
@@ -9,6 +15,7 @@ export const actions = {
   setAuthorStoryOutputStyles: getActionGuid(),
   setAuthorStoryRunnerOptions: getActionGuid(),
   setAuthorStoryRunnerStyles: getActionGuid(),
+  setAuthorStoryStrings: getActionGuid(),
 };
 
 /**
@@ -69,7 +76,7 @@ export const setAuthorStoryOutputStyles = (style: ITextStyle) => {
 /**
  * Sets story options such as logging behavior.
  */
-export const setAuthorStoryRunnerOptions = (options: IRunnerOptions) => {
+export const setAuthorStoryRunnerOptions = (options: IAuthorRunnerOptions) => {
   return {
     type: actions.setAuthorStoryRunnerOptions,
     options,
@@ -84,5 +91,15 @@ export const setAuthorStoryRunnerStyles = (style: IRunnerStyle) => {
   return {
     type: actions.setAuthorStoryRunnerStyles,
     style,
+  };
+};
+
+/**
+ * Overrides special built-in strings relevant to the story.
+ */
+export const setAuthorStoryStrings = (strings: IAuthorRunnerStrings) => {
+  return {
+    type: actions.setAuthorStoryStrings,
+    strings,
   };
 };

--- a/src/common/redux/authorStorySettings.actions.ts
+++ b/src/common/redux/authorStorySettings.actions.ts
@@ -1,0 +1,88 @@
+import { getActionGuid } from "./reduxTools";
+import { IRunnerLogSeparatorStyle, IRunnerStyle, IRunnerOptions, ITextStyle } from "./typedefs";
+
+export const actions = {
+  setAuthorStoryInputStyles: getActionGuid(),
+  setAuthorStoryLogSeparatorStyles: getActionGuid(),
+  setAuthorStoryOptionStyles: getActionGuid(),
+  setAuthorStoryOptionHighlightStyles: getActionGuid(),
+  setAuthorStoryOutputStyles: getActionGuid(),
+  setAuthorStoryRunnerOptions: getActionGuid(),
+  setAuthorStoryRunnerStyles: getActionGuid(),
+};
+
+/**
+ * Sets the global story styling for previous textbox input from the player. This isn't necessarily the final styling.
+ * The order goes built-in defaults -> global story styling -> story style override -> player style override.
+ */
+export const setAuthorStoryInputStyles = (style: ITextStyle) => {
+  return {
+    type: actions.setAuthorStoryInputStyles,
+    style,
+  };
+};
+
+/*
+ * Sets the global story styling for the log separator. This isn't necessarily the final styling. The order goes
+ * built-in defaults -> global story styling -> player style override.
+ */
+export const setAuthorStoryLogSeparatorStyles = (style: IRunnerLogSeparatorStyle) => {
+  return {
+    type: actions.setAuthorStoryLogSeparatorStyles,
+    style,
+  };
+};
+
+/**
+ * Sets the global story styling for hyperlinks in the story. This isn't necessarily the final styling. The order goes
+ * built-in defaults -> global story styling -> story style override -> player style override.
+ */
+export const setAuthorStoryOptionStyles = (style: ITextStyle) => {
+  return {
+    type: actions.setAuthorStoryOptionStyles,
+    style,
+  };
+};
+
+/**
+ * Sets the global story styling for hovered hyperlinks in the story. This isn't necessarily the final styling. The
+ * order goes built-in defaults -> global story styling -> story style override -> player style override.
+ */
+export const setAuthorStoryOptionHighlightStyles = (style: ITextStyle) => {
+  return {
+    type: actions.setAuthorStoryOptionHighlightStyles,
+    style,
+  };
+};
+
+/**
+ * Sets the global story styling for all text output from the story. This isn't necessarily the final styling. The
+ * order goes built-in defaults -> global story styling -> story style override -> player style override.
+ */
+export const setAuthorStoryOutputStyles = (style: ITextStyle) => {
+  return {
+    type: actions.setAuthorStoryOutputStyles,
+    style,
+  };
+};
+
+/**
+ * Sets story options such as logging behavior.
+ */
+export const setAuthorStoryRunnerOptions = (options: IRunnerOptions) => {
+  return {
+    type: actions.setAuthorStoryRunnerOptions,
+    options,
+  };
+};
+
+/**
+ * Sets the global story styling for the runner itself. This isn't necessarily the final styling. The order goes
+ * built-in defaults -> global story styling -> story style override -> player style override.
+ */
+export const setAuthorStoryRunnerStyles = (style: IRunnerStyle) => {
+  return {
+    type: actions.setAuthorStoryRunnerStyles,
+    style,
+  };
+};

--- a/src/common/redux/authorStorySettings.reducers.ts
+++ b/src/common/redux/authorStorySettings.reducers.ts
@@ -56,9 +56,20 @@ const authorStoryRunnerOptions = (state = {}, action: ReturnType<typeof actions.
   return state;
 };
 
-const authorStoryRunnerStyles = (state = {}, action: ReturnType<typeof actions.setAuthorStoryRunnerStyles>) => {
+const authorStoryRunnerStyles = (
+  state = { background: { type: "plain" } },
+  action: ReturnType<typeof actions.setAuthorStoryRunnerStyles>
+) => {
   if (action.type === actions.actions.setAuthorStoryRunnerStyles) {
     return action.style;
+  }
+
+  return state;
+};
+
+const authorStoryStrings = (state = {}, action: ReturnType<typeof actions.setAuthorStoryStrings>) => {
+  if (action.type === actions.actions.setAuthorStoryStrings) {
+    return action.strings;
   }
 
   return state;
@@ -86,7 +97,7 @@ export const dispatchSetAuthorStoryOutputStyles = (dispatch: Dispatch) => (style
   dispatch(actions.setAuthorStoryOutputStyles(style));
 };
 
-export const dispatchSetAuthorStoryRunnerOptions = (dispatch: Dispatch) => (options: types.IRunnerOptions) => {
+export const dispatchSetAuthorStoryRunnerOptions = (dispatch: Dispatch) => (options: types.IAuthorRunnerOptions) => {
   dispatch(actions.setAuthorStoryRunnerOptions(options));
 };
 
@@ -94,15 +105,20 @@ export const dispatchSetAuthorStoryRunnerStyles = (dispatch: Dispatch) => (style
   dispatch(actions.setAuthorStoryRunnerStyles(style));
 };
 
+export const dispatchSetAuthorStoryStrings = (dispatch: Dispatch) => (strings: types.IAuthorRunnerStrings) => {
+  dispatch(actions.setAuthorStoryStrings(strings));
+};
+
 // Combine reducers and typescript definition.
 export interface IAuthorStorySettingsState {
-  authorStoryInputStyles: string;
-  authorStoryLogSeparatorStyles: string;
-  authorStoryOptionStyles: string;
-  authorStoryOptionHighlightStyles: string;
-  authorStoryOutputStyles: string;
-  authorStoryRunnerOptions: string;
-  authorStoryRunnerStyles: string;
+  authorStoryInputStyles: types.ITextStyle;
+  authorStoryLogSeparatorStyles: types.IRunnerLogSeparatorStyle;
+  authorStoryOptionStyles: types.ITextStyle;
+  authorStoryOptionHighlightStyles: types.ITextStyle;
+  authorStoryOutputStyles: types.ITextStyle;
+  authorStoryRunnerOptions: types.IAuthorRunnerOptions;
+  authorStoryRunnerStyles: types.IRunnerStyle;
+  authorStoryStrings: types.IAuthorRunnerStrings;
 }
 
 export const authorStorySettings = combineReducers({
@@ -113,4 +129,5 @@ export const authorStorySettings = combineReducers({
   authorStoryOutputStyles,
   authorStoryRunnerOptions,
   authorStoryRunnerStyles,
+  authorStoryStrings,
 });

--- a/src/common/redux/authorStorySettings.reducers.ts
+++ b/src/common/redux/authorStorySettings.reducers.ts
@@ -1,0 +1,116 @@
+import { combineReducers, Dispatch } from "redux";
+import * as actions from "./authorStorySettings.actions";
+import * as types from "./typedefs";
+
+const authorStoryInputStyles = (state = {}, action: ReturnType<typeof actions.setAuthorStoryInputStyles>) => {
+  if (action.type === actions.actions.setAuthorStoryInputStyles) {
+    return action.style;
+  }
+
+  return state;
+};
+
+const authorStoryLogSeparatorStyles = (
+  state = {},
+  action: ReturnType<typeof actions.setAuthorStoryLogSeparatorStyles>
+) => {
+  if (action.type === actions.actions.setAuthorStoryLogSeparatorStyles) {
+    return action.style;
+  }
+
+  return state;
+};
+
+const authorStoryOptionStyles = (state = {}, action: ReturnType<typeof actions.setAuthorStoryOptionStyles>) => {
+  if (action.type === actions.actions.setAuthorStoryOptionStyles) {
+    return action.style;
+  }
+
+  return state;
+};
+
+const authorStoryOptionHighlightStyles = (
+  state = {},
+  action: ReturnType<typeof actions.setAuthorStoryOptionHighlightStyles>
+) => {
+  if (action.type === actions.actions.setAuthorStoryOptionHighlightStyles) {
+    return action.style;
+  }
+
+  return state;
+};
+
+const authorStoryOutputStyles = (state = {}, action: ReturnType<typeof actions.setAuthorStoryOutputStyles>) => {
+  if (action.type === actions.actions.setAuthorStoryOutputStyles) {
+    return action.style;
+  }
+
+  return state;
+};
+
+const authorStoryRunnerOptions = (state = {}, action: ReturnType<typeof actions.setAuthorStoryRunnerOptions>) => {
+  if (action.type === actions.actions.setAuthorStoryRunnerOptions) {
+    return action.options;
+  }
+
+  return state;
+};
+
+const authorStoryRunnerStyles = (state = {}, action: ReturnType<typeof actions.setAuthorStoryRunnerStyles>) => {
+  if (action.type === actions.actions.setAuthorStoryRunnerStyles) {
+    return action.style;
+  }
+
+  return state;
+};
+
+export const dispatchSetAuthorStoryInputStyles = (dispatch: Dispatch) => (style: types.ITextStyle) => {
+  dispatch(actions.setAuthorStoryInputStyles(style));
+};
+
+export const dispatchSetAuthorStoryLogSeparatorStyles = (dispatch: Dispatch) => (
+  style: types.IRunnerLogSeparatorStyle
+) => {
+  dispatch(actions.setAuthorStoryLogSeparatorStyles(style));
+};
+
+export const dispatchSetAuthorStoryOptionStyles = (dispatch: Dispatch) => (style: types.ITextStyle) => {
+  dispatch(actions.setAuthorStoryOptionStyles(style));
+};
+
+export const dispatchSetAuthorStoryOptionHighlightStyles = (dispatch: Dispatch) => (style: types.ITextStyle) => {
+  dispatch(actions.setAuthorStoryOptionHighlightStyles(style));
+};
+
+export const dispatchSetAuthorStoryOutputStyles = (dispatch: Dispatch) => (style: types.ITextStyle) => {
+  dispatch(actions.setAuthorStoryOutputStyles(style));
+};
+
+export const dispatchSetAuthorStoryRunnerOptions = (dispatch: Dispatch) => (options: types.IRunnerOptions) => {
+  dispatch(actions.setAuthorStoryRunnerOptions(options));
+};
+
+export const dispatchSetAuthorStoryRunnerStyles = (dispatch: Dispatch) => (style: types.IRunnerStyle) => {
+  dispatch(actions.setAuthorStoryRunnerStyles(style));
+};
+
+// Combine reducers and typescript definition.
+export interface IAuthorStorySettingsState {
+  authorStoryInputStyles: string;
+  authorStoryLogSeparatorStyles: string;
+  authorStoryOptionStyles: string;
+  authorStoryOptionHighlightStyles: string;
+  authorStoryOutputStyles: string;
+  authorStoryRunnerOptions: string;
+  authorStoryRunnerStyles: string;
+}
+
+export const authorStorySettings = combineReducers({
+  authorStoryInputStyles,
+  authorStoryLogSeparatorStyles,
+  authorStoryOptionStyles,
+  authorStoryOptionHighlightStyles,
+  authorStoryOutputStyles,
+  authorStoryRunnerOptions,
+  authorStoryRunnerStyles,
+});

--- a/src/common/redux/currentRunnerSettings.actions.ts
+++ b/src/common/redux/currentRunnerSettings.actions.ts
@@ -1,0 +1,22 @@
+import { getActionGuid } from "./reduxTools";
+import { IAuthorRunnerOptions } from "./typedefs";
+
+export const actions = {
+  clearAllTempSettings: getActionGuid(),
+  setCurrentRunnerOptions: getActionGuid(),
+};
+
+/** Resets all temp settings to minimal defaults. */
+export const clearAllTempSettings = {
+  type: actions.clearAllTempSettings,
+};
+
+/**
+ * Sets story options such as logging behavior.
+ */
+export const setCurrentRunnerOptions = (options: IAuthorRunnerOptions) => {
+  return {
+    type: actions.setCurrentRunnerOptions,
+    options,
+  };
+};

--- a/src/common/redux/currentRunnerSettings.reducers.ts
+++ b/src/common/redux/currentRunnerSettings.reducers.ts
@@ -1,0 +1,31 @@
+import { combineReducers, Dispatch } from "redux";
+import * as actions from "./currentRunnerSettings.actions";
+import * as types from "./typedefs";
+
+const currentRunnerOptions = (state = {}, action: ReturnType<typeof actions.setCurrentRunnerOptions>) => {
+  if (action.type === actions.actions.setCurrentRunnerOptions) {
+    return action.options;
+  }
+  if (action.type === actions.actions.clearAllTempSettings) {
+    return {};
+  }
+
+  return state;
+};
+
+export const dispatchClearAllTempSettings = (dispatch: Dispatch) => {
+  dispatch(actions.clearAllTempSettings);
+};
+
+export const dispatchSetTempStoryRunnerOptions = (dispatch: Dispatch) => (options: types.IAuthorRunnerOptions) => {
+  dispatch(actions.setCurrentRunnerOptions(options));
+};
+
+// Combine reducers and typescript definition.
+export interface ICurrentRunnerSettingsState {
+  currentRunnerSettings: types.IAuthorRunnerOptions;
+}
+
+export const currentRunnerSettings = combineReducers({
+  currentRunnerOptions,
+});

--- a/src/common/redux/playerStorySettings.actions.ts
+++ b/src/common/redux/playerStorySettings.actions.ts
@@ -1,5 +1,5 @@
 import { getActionGuid } from "./reduxTools";
-import { IRunnerLogSeparatorStyle, IRunnerStyle, IRunnerOptions, ITextStyle } from "./typedefs";
+import { IRunnerLogSeparatorStyle, IRunnerStyle, IPlayerRunnerOptions, ITextStyle } from "./typedefs";
 
 export const actions = {
   setPlayerStoryInputStyles: getActionGuid(),
@@ -69,7 +69,7 @@ export const setPlayerStoryOutputStyles = (style: ITextStyle) => {
 /**
  * Sets story options such as logging behavior.
  */
-export const setPlayerStoryRunnerOptions = (options: IRunnerOptions) => {
+export const setPlayerStoryRunnerOptions = (options: IPlayerRunnerOptions) => {
   return {
     type: actions.setPlayerStoryRunnerOptions,
     options,

--- a/src/common/redux/playerStorySettings.actions.ts
+++ b/src/common/redux/playerStorySettings.actions.ts
@@ -1,0 +1,88 @@
+import { getActionGuid } from "./reduxTools";
+import { IRunnerLogSeparatorStyle, IRunnerStyle, IRunnerOptions, ITextStyle } from "./typedefs";
+
+export const actions = {
+  setPlayerStoryInputStyles: getActionGuid(),
+  setPlayerStoryLogSeparatorStyles: getActionGuid(),
+  setPlayerStoryOptionStyles: getActionGuid(),
+  setPlayerStoryOptionHighlightStyles: getActionGuid(),
+  setPlayerStoryOutputStyles: getActionGuid(),
+  setPlayerStoryRunnerOptions: getActionGuid(),
+  setPlayerStoryRunnerStyles: getActionGuid(),
+};
+
+/**
+ * Sets the player preferred styling for previous textbox input from the player. This is the final styling.
+ * The order goes built-in defaults -> global story styling -> story style override -> player style override.
+ */
+export const setPlayerStoryInputStyles = (style: ITextStyle) => {
+  return {
+    type: actions.setPlayerStoryInputStyles,
+    style,
+  };
+};
+
+/*
+ * Sets the player preferred styling for the log separator. This is the final styling. The order goes
+ * built-in defaults -> global story styling -> player style override.
+ */
+export const setPlayerStoryLogSeparatorStyles = (style: IRunnerLogSeparatorStyle) => {
+  return {
+    type: actions.setPlayerStoryLogSeparatorStyles,
+    style,
+  };
+};
+
+/**
+ * Sets the player preferred styling for hyperlinks in the story. This is the final styling. The order goes
+ * built-in defaults -> global story styling -> story style override -> player style override.
+ */
+export const setPlayerStoryOptionStyles = (style: ITextStyle) => {
+  return {
+    type: actions.setPlayerStoryOptionStyles,
+    style,
+  };
+};
+
+/**
+ * Sets the player preferred styling for hovered hyperlinks in the story. This is the final styling. The
+ * order goes built-in defaults -> global story styling -> story style override -> player style override.
+ */
+export const setPlayerStoryOptionHighlightStyles = (style: ITextStyle) => {
+  return {
+    type: actions.setPlayerStoryOptionHighlightStyles,
+    style,
+  };
+};
+
+/**
+ * Sets the player preferred styling for all text output from the story. This is the final styling. The
+ * order goes built-in defaults -> global story styling -> story style override -> player style override.
+ */
+export const setPlayerStoryOutputStyles = (style: ITextStyle) => {
+  return {
+    type: actions.setPlayerStoryOutputStyles,
+    style,
+  };
+};
+
+/**
+ * Sets story options such as logging behavior.
+ */
+export const setPlayerStoryRunnerOptions = (options: IRunnerOptions) => {
+  return {
+    type: actions.setPlayerStoryRunnerOptions,
+    options,
+  };
+};
+
+/**
+ * Sets the player preferred styling for the runner itself. This is the final styling. The order goes
+ * built-in defaults -> global story styling -> story style override -> player style override.
+ */
+export const setPlayerStoryRunnerStyles = (style: IRunnerStyle) => {
+  return {
+    type: actions.setPlayerStoryRunnerStyles,
+    style,
+  };
+};

--- a/src/common/redux/playerStorySettings.reducers.ts
+++ b/src/common/redux/playerStorySettings.reducers.ts
@@ -56,7 +56,10 @@ const playerStoryRunnerOptions = (state = {}, action: ReturnType<typeof actions.
   return state;
 };
 
-const playerStoryRunnerStyles = (state = {}, action: ReturnType<typeof actions.setPlayerStoryRunnerStyles>) => {
+const playerStoryRunnerStyles = (
+  state = { background: { type: "plain" } },
+  action: ReturnType<typeof actions.setPlayerStoryRunnerStyles>
+) => {
   if (action.type === actions.actions.setPlayerStoryRunnerStyles) {
     return action.style;
   }
@@ -86,7 +89,7 @@ export const dispatchSetPlayerStoryOutputStyles = (dispatch: Dispatch) => (style
   dispatch(actions.setPlayerStoryOutputStyles(style));
 };
 
-export const dispatchSetPlayerStoryRunnerOptions = (dispatch: Dispatch) => (options: types.IRunnerOptions) => {
+export const dispatchSetPlayerStoryRunnerOptions = (dispatch: Dispatch) => (options: types.IPlayerRunnerOptions) => {
   dispatch(actions.setPlayerStoryRunnerOptions(options));
 };
 
@@ -96,13 +99,13 @@ export const dispatchSetPlayerStoryRunnerStyles = (dispatch: Dispatch) => (style
 
 // Combine reducers and typescript definition.
 export interface IPlayerStorySettingsState {
-  playerStoryInputStyles: string;
-  playerStoryLogSeparatorStyles: string;
-  playerStoryOptionStyles: string;
-  playerStoryOptionHighlightStyles: string;
-  playerStoryOutputStyles: string;
-  playerStoryRunnerOptions: string;
-  playerStoryRunnerStyles: string;
+  playerStoryInputStyles: types.ITextStyle;
+  playerStoryLogSeparatorStyles: types.IRunnerLogSeparatorStyle;
+  playerStoryOptionStyles: types.ITextStyle;
+  playerStoryOptionHighlightStyles: types.ITextStyle;
+  playerStoryOutputStyles: types.ITextStyle;
+  playerStoryRunnerOptions: types.IPlayerRunnerOptions;
+  playerStoryRunnerStyles: types.IRunnerStyle;
 }
 
 export const playerStorySettings = combineReducers({

--- a/src/common/redux/playerStorySettings.reducers.ts
+++ b/src/common/redux/playerStorySettings.reducers.ts
@@ -1,0 +1,116 @@
+import { combineReducers, Dispatch } from "redux";
+import * as actions from "./playerStorySettings.actions";
+import * as types from "./typedefs";
+
+const playerStoryInputStyles = (state = {}, action: ReturnType<typeof actions.setPlayerStoryInputStyles>) => {
+  if (action.type === actions.actions.setPlayerStoryInputStyles) {
+    return action.style;
+  }
+
+  return state;
+};
+
+const playerStoryLogSeparatorStyles = (
+  state = {},
+  action: ReturnType<typeof actions.setPlayerStoryLogSeparatorStyles>
+) => {
+  if (action.type === actions.actions.setPlayerStoryLogSeparatorStyles) {
+    return action.style;
+  }
+
+  return state;
+};
+
+const playerStoryOptionStyles = (state = {}, action: ReturnType<typeof actions.setPlayerStoryOptionStyles>) => {
+  if (action.type === actions.actions.setPlayerStoryOptionStyles) {
+    return action.style;
+  }
+
+  return state;
+};
+
+const playerStoryOptionHighlightStyles = (
+  state = {},
+  action: ReturnType<typeof actions.setPlayerStoryOptionHighlightStyles>
+) => {
+  if (action.type === actions.actions.setPlayerStoryOptionHighlightStyles) {
+    return action.style;
+  }
+
+  return state;
+};
+
+const playerStoryOutputStyles = (state = {}, action: ReturnType<typeof actions.setPlayerStoryOutputStyles>) => {
+  if (action.type === actions.actions.setPlayerStoryOutputStyles) {
+    return action.style;
+  }
+
+  return state;
+};
+
+const playerStoryRunnerOptions = (state = {}, action: ReturnType<typeof actions.setPlayerStoryRunnerOptions>) => {
+  if (action.type === actions.actions.setPlayerStoryRunnerOptions) {
+    return action.options;
+  }
+
+  return state;
+};
+
+const playerStoryRunnerStyles = (state = {}, action: ReturnType<typeof actions.setPlayerStoryRunnerStyles>) => {
+  if (action.type === actions.actions.setPlayerStoryRunnerStyles) {
+    return action.style;
+  }
+
+  return state;
+};
+
+export const dispatchSetPlayerStoryInputStyles = (dispatch: Dispatch) => (style: types.ITextStyle) => {
+  dispatch(actions.setPlayerStoryInputStyles(style));
+};
+
+export const dispatchSetPlayerStoryLogSeparatorStyles = (dispatch: Dispatch) => (
+  style: types.IRunnerLogSeparatorStyle
+) => {
+  dispatch(actions.setPlayerStoryLogSeparatorStyles(style));
+};
+
+export const dispatchSetPlayerStoryOptionStyles = (dispatch: Dispatch) => (style: types.ITextStyle) => {
+  dispatch(actions.setPlayerStoryOptionStyles(style));
+};
+
+export const dispatchSetPlayerStoryOptionHighlightStyles = (dispatch: Dispatch) => (style: types.ITextStyle) => {
+  dispatch(actions.setPlayerStoryOptionHighlightStyles(style));
+};
+
+export const dispatchSetPlayerStoryOutputStyles = (dispatch: Dispatch) => (style: types.ITextStyle) => {
+  dispatch(actions.setPlayerStoryOutputStyles(style));
+};
+
+export const dispatchSetPlayerStoryRunnerOptions = (dispatch: Dispatch) => (options: types.IRunnerOptions) => {
+  dispatch(actions.setPlayerStoryRunnerOptions(options));
+};
+
+export const dispatchSetPlayerStoryRunnerStyles = (dispatch: Dispatch) => (style: types.IRunnerStyle) => {
+  dispatch(actions.setPlayerStoryRunnerStyles(style));
+};
+
+// Combine reducers and typescript definition.
+export interface IPlayerStorySettingsState {
+  playerStoryInputStyles: string;
+  playerStoryLogSeparatorStyles: string;
+  playerStoryOptionStyles: string;
+  playerStoryOptionHighlightStyles: string;
+  playerStoryOutputStyles: string;
+  playerStoryRunnerOptions: string;
+  playerStoryRunnerStyles: string;
+}
+
+export const playerStorySettings = combineReducers({
+  playerStoryInputStyles,
+  playerStoryLogSeparatorStyles,
+  playerStoryOptionStyles,
+  playerStoryOptionHighlightStyles,
+  playerStoryOutputStyles,
+  playerStoryRunnerOptions,
+  playerStoryRunnerStyles,
+});

--- a/src/common/redux/typedefs.d.ts
+++ b/src/common/redux/typedefs.d.ts
@@ -1,0 +1,118 @@
+/** Determines the appearance of text. */
+export interface ITextStyle {
+  /** Text color as seen in dark theme. Defaults to dark theme text color. */
+  colorDark?: string;
+
+  /** Text color as seen in light theme. Defaults to light theme text color. */
+  colorLight?: string;
+
+  /** Text size. Defaults to 1 rem. */
+  fontSize?: string;
+
+  /** Font styles (i = italic, b = bold, u = underline). Defaults to being unstyled. */
+  fontStyle?: "i" | "b" | "u" | "ib" | "iu" | "bu" | "ibu";
+
+  /** Font family. Defaults to the app font fallback list. */
+  font?: string;
+}
+
+/** Determines the appearance of a border. */
+export interface IBorderStyle {
+  /** Defaults to dark theme text color. */
+  colorDark?: string;
+
+  /** Defaults to light theme text color. */
+  colorLight?: string;
+
+  /** Defaults to solid. */
+  style?: "dotted" | "dashed" | "double";
+
+  /** Defaults to 0.07 rem. */
+  thickness?: number;
+
+  /** Defaults to being sharp (no border radius). */
+  cornerRounding?: "semiround" | "round";
+}
+
+/** Determines the appearance of the log separator. */
+export interface IRunnerLogSeparatorStyle {
+  style: (IRunnerLogSeparatorBarStyle & { type: "bar" }) | (IRunnerLogSeparatorImageStyle & { type: "image" });
+}
+
+/** Determines the appearance of a line separating old and current page contents. */
+export interface IRunnerLogSeparatorBarStyle extends IBorderStyle {}
+
+/** Determines the appearance of an image separating old and current page elements. */
+export interface IRunnerLogSeparatorImageStyle {
+  /**
+   * Determines how images respond to story width, scaling only horizontally or both horizontally and vertically until
+   * the image touches both sides of the story column width. Defaults to no scaling.
+   */
+  scaling?: "scaleWide" | "scaleBoth";
+
+  /** Image path. It can be a relative local file url, or an absolute web url without the protocol. */
+  imageUrl: string;
+}
+
+/** Determines the overall appearance of the player. */
+export interface IRunnerStyle {
+  /** The background can be plain or an image. */
+  background: (IRunnerPlainStyle & { type: "plain" }) | (IRunnerImageStyle & { type: "image" });
+}
+
+/** Determines the appearance of a plain background for the player. */
+export interface IRunnerPlainStyle {
+  /** Background color of the player as seen in dark mode. Defaults to dark theme background color. */
+  colorDark?: string;
+
+  /** Background color of the player as seen in light mode. Defaults to light theme background color. */
+  colorLight?: string;
+}
+
+/** Determines the appearance of an image background for the player. */
+export interface IRunnerImageStyle {
+  /**
+   * Tiling display style. The image can stretch horizontally and tile vertically, or tile in both directions. Defaults
+   * to stretching to fill visible space (without moving when the user scrolls).
+   */
+  tileMode?: "tileVertical" | "tileBoth";
+
+  /** Image path. It can be a relative local file url, or an absolute web url without the protocol. */
+  imageUrl: string;
+
+  /** A rectangle below the text and above the background image. By default, no underlay is shown. */
+  textUnderlay?: IRunnerTextUnderlayStyle;
+}
+
+/** Determines the appearance of a rectangle between the background image and page contents. */
+export interface IRunnerTextUnderlayStyle {
+  /** Styles the border of a rectangle above the background image and below the text. Defaults to no border. */
+  border?: IBorderStyle;
+
+  /** Color of the underlay rectangle as seen in dark theme. Defaults to dark theme text color. */
+  colorDark?: string;
+
+  /** Color of the underlay rectangle as seen in light theme. Defaults to light theme text color. */
+  colorLight?: string;
+
+  /** Opacity of the underlay rectangle as a value from 0 (translucent) to 1 (opaque). Defaults to 1. */
+  opacity?: number;
+}
+
+/** Options affecting the behavior of the player. */
+export interface IRunnerOptions {
+  /** Number of output and input blocks to preserve. Default unrestricted. */
+  logLimit?: number;
+
+  /** Whether to show old output and input blocks in the player. Default true. */
+  showLog?: false;
+}
+
+// prebuilt style profiles for simplicity so people don't have to fiddle with everything (and ability to define new ones)
+// spelling/grammar
+// autosave and manual save control
+// file format needs a section for plugin data and a callback to handle it. Use a dict with plugin name as key.
+// hyperlink styling
+// feature to register plugins once they have loaded, using a unique key. Feature to require players to have named plugins (with download hyperlink and notes).
+// track version
+// keyboard shortcuts and overrides (nothing affecting the player)

--- a/src/common/redux/typedefs.d.ts
+++ b/src/common/redux/typedefs.d.ts
@@ -99,20 +99,50 @@ export interface IRunnerTextUnderlayStyle {
   opacity?: number;
 }
 
-/** Options affecting the behavior of the player. */
-export interface IRunnerOptions {
+/** Options the author chooses that affect the behavior of the runner. */
+export interface IAuthorRunnerOptions {
+  /**
+   * If true, inline links are styled like regular text. The beam cursor is used. This doesn't prevent screen readers
+   * or tabbing from revealing inline links.
+   */
+  discreteInlineLinks?: true;
+
+  /** Whether to hide old output and input blocks in the runner. Default false. */
+  hideLog?: true;
+
+  /** Whether to hide the restart link when there are no hyperlinks out of a page. Default false. */
+  hideRestartLink?: true;
+
   /** Number of output and input blocks to preserve. Default unrestricted. */
   logLimit?: number;
 
-  /** Whether to show old output and input blocks in the player. Default true. */
-  showLog?: false;
+  /** A seed to use for random number generation, if provided. Defaults to a value based on the current millisecond. */
+  randomSeed?: number;
 }
 
-// prebuilt style profiles for simplicity so people don't have to fiddle with everything (and ability to define new ones)
-// spelling/grammar
-// autosave and manual save control
-// file format needs a section for plugin data and a callback to handle it. Use a dict with plugin name as key.
-// hyperlink styling
-// feature to register plugins once they have loaded, using a unique key. Feature to require players to have named plugins (with download hyperlink and notes).
-// track version
-// keyboard shortcuts and overrides (nothing affecting the player)
+/** String overrides for built-in strings. */
+export interface IAuthorRunnerStrings {
+  /** Overrides the text for the default restart link. Defaults to "restart". */
+  restartLinkText?: string;
+}
+
+/** Options the player chooses that affect the behavior of the runner. */
+export interface IPlayerRunnerOptions {
+  /**
+   * A value from 0 to 1 for the volume of all audio, overriding author settings. Audio doesn't play or load if the
+   * value is 0. Defaults to 1.
+   */
+  audioVolume?: number;
+
+  /** Doesn't show or load graphics when true. Defaults to false. */
+  disableGraphics?: true;
+
+  /** If true, does not populate suggestions for commands in the textbox. False by default. */
+  disableTextSuggestions?: true;
+
+  /** If true, audio elements only play on touch. False by default. */
+  manualAudio?: true;
+
+  /** If true, graphical elements are hidden until revealed by touch. False by default. */
+  manualGraphics?: true;
+}

--- a/src/common/redux/viewedit.reducers.ts
+++ b/src/common/redux/viewedit.reducers.ts
@@ -29,7 +29,22 @@ const storyToParse = (state = "", action: ReturnType<typeof saveAndRunStory>) =>
   return state;
 };
 
-/** Uses a number to indicate that the runner should re-render. */
+/**
+ * Uses a number to indicate that the story should be parsed again. Necessary because there is no good way to pass the
+ * action from the editor to runner, and restarting without the story text changing is a common operation.
+ */
+const storyReparseToken = (state = 0, action: ReturnType<typeof saveAndRunStory>) => {
+  if (action.type === actions.saveAndRunStory) {
+    return state + 1;
+  }
+
+  return state;
+};
+
+/**
+ * Uses a number to indicate that the runner should re-render. The alternative is to re-render any time output, input,
+ * and logs change, which gets up to 20-30 re-renders per new page. Instead, increment this when the page is done.
+ */
 const storyRerenderToken = (state = 0, action: typeof rerenderStory) => {
   if (action.type === actions.rerenderStory) {
     return state + 1;
@@ -56,12 +71,14 @@ export const dispatchRerenderStory = (dispatch: Dispatch) => () => {
 // Combine reducers and typescript definition.
 export interface IViewEditState {
   story: string;
-  storyRerenderToken: string;
+  storyReparseToken: number;
+  storyRerenderToken: number;
   storyToParse: string;
 }
 
 export const viewEdit = combineReducers({
   story,
+  storyReparseToken,
   storyRerenderToken,
   storyToParse,
 });

--- a/src/common/styles/interpreterStyles.ts
+++ b/src/common/styles/interpreterStyles.ts
@@ -1,0 +1,122 @@
+import { ITextStyle } from "../redux/typedefs";
+import { ISupportedTheme, themes } from "../themes";
+import { fallbackFontStack } from "./controlStyles";
+
+/** Declaring the element type allows the interpreter to select the right fallback styles. */
+export enum fallbackElementType {
+  input,
+  option,
+  optionHighlight,
+  output,
+}
+
+/**
+ * The inherent styles used for different elements, if no other style is applied.
+ * Note that the redundant casting below is necessary as of TS 4.0.3 due to type resolution problems.
+ */
+const fallbackStyles = {
+  [fallbackElementType.input]: {
+    colorLight: themes.light.theme.semanticColors.errorText,
+    colorDark: themes.dark.theme.semanticColors.errorText,
+    fontFamily: fallbackFontStack,
+    fontSize: "1.2 rem",
+    fontStyle: "normal" as "normal",
+    fontWeight: "normal" as "normal",
+    textDecoration: "inherit" as "inherit",
+  },
+  [fallbackElementType.option]: {
+    colorLight: themes.light.theme.semanticColors.link,
+    colorDark: themes.dark.theme.semanticColors.link,
+    fontFamily: fallbackFontStack,
+    fontSize: "1.2 rem",
+    fontStyle: "normal" as "normal",
+    fontWeight: "normal" as "normal",
+    textDecoration: "underline" as "underline",
+  },
+  [fallbackElementType.optionHighlight]: {
+    colorLight: themes.light.theme.semanticColors.linkHovered,
+    colorDark: themes.dark.theme.semanticColors.linkHovered,
+    fontFamily: fallbackFontStack,
+    fontSize: "1.2 rem",
+    fontStyle: "normal" as "normal",
+    fontWeight: "normal" as "normal",
+    textDecoration: "underline" as "underline",
+  },
+  [fallbackElementType.output]: {
+    colorLight: themes.light.theme.semanticColors.bodyText,
+    colorDark: themes.dark.theme.semanticColors.bodyText,
+    fontFamily: fallbackFontStack,
+    fontSize: "1.2 rem",
+    fontStyle: "normal" as "normal",
+    fontWeight: "normal" as "normal",
+    textDecoration: "inherit" as "inherit",
+  },
+};
+
+/**
+ * Applies text styles to determine font family, size, bold/italic/underline, and color. Players can set their own
+ * style overrides (playerStyle). The author can set styles within the game that deviate from the normal styling
+ * (storyStyle), and set a global default style for the story (authorStyle). When editing a story, playerStyle should
+ * be left empty. PlayerStyle overrides storyStyle, which overrides authorStyle. Overrides work per attribute, and
+ * fall down to the next style if not met, or a natural default if none are met.
+ *
+ * Light colors are used in lightMode and dark colors in darkMode, as defined by the theming.
+ *
+ * @param playerStyle Styles that a player has set to override all styles in stories they read, if set.
+ * @param storyStyle Specific one-off styling within the story.
+ * @param authorStyle Styles that an author has set as the default text styling.
+ */
+export const getTextStyle = (
+  theme: ISupportedTheme,
+  playerStyle: ITextStyle,
+  storyStyle: ITextStyle,
+  authorStyle: ITextStyle,
+  fallback: fallbackElementType
+): React.CSSProperties => {
+  const fallbackStyle = fallbackStyles[fallback];
+
+  const color =
+    theme.localizedName === themes.light.localizedName
+      ? playerStyle.colorLight || storyStyle.colorLight || authorStyle.colorLight || fallbackStyle.colorLight
+      : playerStyle.colorDark || storyStyle.colorDark || authorStyle.colorDark || fallbackStyle.colorDark;
+
+  const fontFamily = playerStyle.font || storyStyle.font || authorStyle.font || fallbackStyle.fontFamily;
+  const fontSize = playerStyle.fontSize || storyStyle.fontSize || authorStyle.fontSize || fallbackStyle.fontSize;
+
+  let fontStyle: "italic" | "normal" = "normal";
+  let fontWeight: "bold" | "normal" = "normal";
+  let textDecoration: "underline" | "inherit" = "inherit";
+
+  if (playerStyle.fontStyle) {
+    fontStyle = playerStyle.fontStyle.includes("i") ? "italic" : fallbackStyle.fontStyle;
+  } else if (storyStyle.fontStyle) {
+    fontStyle = storyStyle.fontStyle.includes("i") ? "italic" : fallbackStyle.fontStyle;
+  } else if (authorStyle.fontStyle) {
+    fontStyle = authorStyle.fontStyle.includes("i") ? "italic" : fallbackStyle.fontStyle;
+  }
+
+  if (playerStyle.fontStyle) {
+    fontWeight = playerStyle.fontStyle.includes("b") ? "bold" : fallbackStyle.fontWeight;
+  } else if (storyStyle.fontStyle) {
+    fontWeight = storyStyle.fontStyle.includes("b") ? "bold" : fallbackStyle.fontWeight;
+  } else if (authorStyle.fontStyle) {
+    fontWeight = authorStyle.fontStyle.includes("b") ? "bold" : fallbackStyle.fontWeight;
+  }
+
+  if (playerStyle.fontStyle) {
+    textDecoration = playerStyle.fontStyle.includes("u") ? "underline" : fallbackStyle.textDecoration;
+  } else if (storyStyle.fontStyle) {
+    textDecoration = storyStyle.fontStyle.includes("u") ? "underline" : fallbackStyle.textDecoration;
+  } else if (authorStyle.fontStyle) {
+    textDecoration = authorStyle.fontStyle.includes("u") ? "underline" : fallbackStyle.textDecoration;
+  }
+
+  return {
+    color,
+    fontFamily,
+    fontSize,
+    fontStyle,
+    fontWeight,
+    textDecoration,
+  };
+};

--- a/src/gui/runner/RunnerView.tsx
+++ b/src/gui/runner/RunnerView.tsx
@@ -6,6 +6,7 @@ import { IRootState } from "../../store";
 
 const mapStateToProps = (state: IRootState) => {
   return {
+    renderTrigger: state.viewEdit.storyReparseToken, // Needed to re-render without story changing.
     storyToParse: state.viewEdit.storyToParse,
   };
 };

--- a/src/parse-story/storyInterpreter.tsx
+++ b/src/parse-story/storyInterpreter.tsx
@@ -379,41 +379,16 @@ export class StoryInterpreterC extends React.Component<StoryInterpreterOwnProps>
     }
   }
 
-  /** Sets or clears an error message. */
-  public setErrorMessage(error: string | undefined) {
-    this.errorMessage = error ?? "";
-    this.refreshInterpreterGui();
-  }
-
   /** Re-renders the interpreter and applies the chosen background color. */
   public refreshInterpreterGui() {
-    const runner = document.getElementById(idRunnerWrapper);
-
-    if (runner && this.customization.styles.styleRunner.backgroundColor) {
-      runner.style["backgroundColor"] = this.customization.styles.styleRunner.backgroundColor;
-    }
-
     this.refreshInterpreterGuiStyles();
     (this.props as CombinedProps).dispatchRerenderStory();
   }
 
-  private refreshInterpreterGuiStyles() {
-    const themeStyles =
-      (this.props as CombinedProps).theme.localizedName === themes.light.localizedName
-        ? this.defaultLightThemeStyle
-        : this.defaultDarkThemeStyle;
-
-    this.customization.styles = {
-      styleInput: { ...themeStyles.styleInput },
-      styleOptions: { ...themeStyles.styleOptions },
-      styleOptionsHighlight: { ...themeStyles.styleOptionsHighlight },
-      styleOutput: { ...themeStyles.styleOutput },
-      styleRunner: { ...themeStyles.styleRunner },
-    };
-  }
-
   /** Renders output. Conditionally renders logs, error message, and textbox. */
   public render(): React.ReactNode {
+    this.refreshInterpreterGuiStyles();
+
     const restartOption =
       this.options.length === 0 && !this.customization.restartOptionDisabled ? this.getRestartLink() : undefined;
 
@@ -487,6 +462,12 @@ export class StoryInterpreterC extends React.Component<StoryInterpreterOwnProps>
         this.setFork(entriesKeys[0]);
       }
     }
+  }
+
+  /** Sets or clears an error message. */
+  public setErrorMessage(error: string | undefined) {
+    this.errorMessage = error ?? "";
+    this.refreshInterpreterGui();
   }
 
   /** For internal use. Sets the fork usually given by parsed entries. */
@@ -1329,6 +1310,29 @@ export class StoryInterpreterC extends React.Component<StoryInterpreterOwnProps>
     this.variablesPrev = {};
 
     this.refreshInterpreterGuiStyles();
+  }
+
+  /** Initializes or resets the gui styles. */
+  private refreshInterpreterGuiStyles() {
+    const themeStyles =
+      (this.props as CombinedProps).theme.localizedName === themes.light.localizedName
+        ? this.defaultLightThemeStyle
+        : this.defaultDarkThemeStyle;
+
+    this.customization.styles = {
+      styleInput: { ...themeStyles.styleInput },
+      styleOptions: { ...themeStyles.styleOptions },
+      styleOptionsHighlight: { ...themeStyles.styleOptionsHighlight },
+      styleOutput: { ...themeStyles.styleOutput },
+      styleRunner: { ...themeStyles.styleRunner },
+    };
+
+    // Updates the background color of the runner.
+    const runner = document.getElementById(idRunnerWrapper);
+
+    if (runner && this.customization.styles.styleRunner.backgroundColor) {
+      runner.style["backgroundColor"] = this.customization.styles.styleRunner.backgroundColor;
+    }
   }
 
   /** Called when a restart link is pressed or restart is invoked. */

--- a/src/parse-story/storyInterpreter.tsx
+++ b/src/parse-story/storyInterpreter.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { StoryParseNode } from "./storyParseNode";
-import { Random } from "../common/random";
 import { IPageDictionary } from "./storyParser";
 import {
   idRunnerContent,
@@ -21,11 +20,6 @@ import {
   runnerInputTextboxStyle,
   runnerWrapperStyle,
   runnerOutputWrapperStyle,
-  runnerDefaultInputStyle,
-  runnerDefaultOptionsStyle,
-  runnerDefaultOptionsHighlightStyle,
-  runnerDefaultOutputStyle,
-  runnerDefaultWrapperStyle,
   fallbackFontStack,
 } from "../common/styles/controlStyles";
 import { themes } from "../common/themes";
@@ -38,6 +32,10 @@ import { TokenBool } from "../parse-expressions/TokenBool";
 import { TokenFunc } from "../parse-expressions/TokenFunc";
 import { TokenId } from "../parse-expressions/TokenId";
 import { TokenNum } from "../parse-expressions/TokenNum";
+import { ITextStyle } from "../common/redux/typedefs";
+import { dispatchSetTempStoryRunnerOptions } from "../common/redux/currentRunnerSettings.reducers";
+import { dispatchSetAuthorStoryRunnerStyles } from "../common/redux/authorStorySettings.reducers";
+import { Random } from "../common/random";
 
 // TODO: localize strings in this file.
 
@@ -51,41 +49,24 @@ const escapeNoBraceRegex = /\\at|\\n|\\s/g;
 
 /** An expression parser used by the interpreter to resolve expressions for variable assignments. */
 const exprParser = new Parser();
+let random: Random | undefined;
 
-/** The interface for the variable dictionary. */
+/** A dictionary of all variables in the current game. */
 interface IVariables {
   [key: string]: number | boolean | string;
 }
 
-interface IInterpreterStyleCustomization {
-  styleInput: { [key: string]: string | number };
-  styleOptions: React.CSSProperties;
-  styleOptionsHighlight: React.CSSProperties;
-  styleOutput: React.CSSProperties;
-  styleRunner: React.CSSProperties;
-}
-
-interface IInterpreterDefaultCustomization {
-  discreteInlineLinks: boolean;
-  preserveOldOutput: boolean;
-  random: Random;
-  restartOptionDisabled: boolean;
-  restartOptionText: string;
-  showErrors: boolean;
-}
-
-interface IInterpreterDynamicCustomization {
-  discreteInlineLinks: boolean;
-  preserveOldOutput: boolean;
-  random: Random;
-  restartOptionDisabled: boolean;
-  restartOptionText: string;
-  showErrors: boolean;
-  styles: IInterpreterStyleCustomization;
-}
+/**
+ * Returns an element that reads from the current state so it updates with theme changes. In being function-based, it's
+ * only recomputed when the element is evaluated.
+ */
+type InterpreterNode = (props: CombinedProps) => JSX.Element;
 
 const mapStateToProps = (state: IRootState) => {
   return {
+    authorStorySettings: state.authorStorySettings,
+    currentStorySettings: state.currentRunnerSettings,
+    playerStorySettings: state.playerStorySettings,
     renderTrigger: state.viewEdit.storyRerenderToken, // Needed to re-render at will.
     theme: state.settings.theme,
   };
@@ -94,12 +75,13 @@ const mapStateToProps = (state: IRootState) => {
 const mapDispatchToProps = (dispatch: Dispatch) => {
   return {
     dispatchRerenderStory: dispatchRerenderStory(dispatch),
+    dispatchSetAuthorStoryRunnerStyles: dispatchSetAuthorStoryRunnerStyles(dispatch),
+    dispatchSetTempStoryRunnerOptions: dispatchSetTempStoryRunnerOptions(dispatch),
   };
 };
 
 type StoryInterpreterOwnProps = {
-  showErrors?: boolean;
-  random?: Random;
+  debugging?: boolean;
 };
 
 type CombinedProps = StoryInterpreterOwnProps &
@@ -111,7 +93,19 @@ export class StoryInterpreterC extends React.Component<StoryInterpreterOwnProps>
   private actions: ((text: string) => void)[] = [];
 
   /** The content of the current page. */
-  private content: JSX.Element[] = [];
+  private content: InterpreterNode[] = [];
+
+  /** The content of the current page after evaluating each item with current theme values. */
+  private contentCached: JSX.Element[] = [];
+
+  /** Story styling of options that are created. Styling precedence is player > story > author. */
+  private currentOptionStyles: ITextStyle = {};
+
+  /** Story styling of options when they are highlighted. Styling precedence is player > story > author. */
+  private currentOptionHighlightStyles: ITextStyle = {};
+
+  /** Story styling of output that gets created. Styling precedence is player > story > author. */
+  private currentOutputStyles: ITextStyle = {};
 
   /** Stores all tree entries. */
   private entries: IPageDictionary = {};
@@ -123,10 +117,16 @@ export class StoryInterpreterC extends React.Component<StoryInterpreterOwnProps>
   private fork = "";
 
   /** Keeps a list of all previous content, if not disabled. */
-  private log: JSX.Element[] = [];
+  private log: InterpreterNode[] = [];
+
+  /** Keeps a list of all previous content after evaluating each item with current theme values, if not disabled. */
+  private logCached: JSX.Element[] = [];
 
   /** Hyperlink options to the next page. */
-  private options: JSX.Element[] = [];
+  private options: InterpreterNode[] = [];
+
+  /** Hyperlink options to the next page, evaluated with current theme values. */
+  private optionsCached: JSX.Element[] = [];
 
   /** Used to stop evaluation of the current fork entirely. */
   private stopEvaluation = false;
@@ -143,59 +143,55 @@ export class StoryInterpreterC extends React.Component<StoryInterpreterOwnProps>
   /** Stores a copy of all variables as they were just before visiting a new page. This is used when saving. */
   private variablesPrev: IVariables = {};
 
-  private defaultDarkThemeStyle: IInterpreterStyleCustomization = {
-    styleInput: runnerDefaultInputStyle(themes.dark.theme),
-    styleOptions: runnerDefaultOptionsStyle(themes.dark.theme),
-    styleOptionsHighlight: runnerDefaultOptionsHighlightStyle(themes.dark.theme),
-    styleOutput: runnerDefaultOutputStyle(themes.dark.theme),
-    styleRunner: runnerDefaultWrapperStyle(themes.dark.theme),
-  };
-
-  private defaultLightThemeStyle: IInterpreterStyleCustomization = {
-    styleInput: runnerDefaultInputStyle(themes.light.theme),
-    styleOptions: runnerDefaultOptionsStyle(themes.light.theme),
-    styleOptionsHighlight: runnerDefaultOptionsHighlightStyle(themes.light.theme),
-    styleOutput: runnerDefaultOutputStyle(themes.light.theme),
-    styleRunner: runnerDefaultWrapperStyle(themes.light.theme),
-  };
-
-  private defaultCustomization: IInterpreterDefaultCustomization = {
-    discreteInlineLinks: false,
-    preserveOldOutput: true,
-    random: new Random(null),
-    restartOptionDisabled: false,
-    restartOptionText: "restart",
-    showErrors: true,
-  };
-
-  /**
-   * The current options and styles associated with the engine. Exposed to read and change styles.
-   * Note that changes will not trigger a re-render.
-   */
-  public customization: IInterpreterDynamicCustomization = {} as IInterpreterDynamicCustomization;
-
   /** The restart link for when a page is empty or the link is forcibly shown. */
-  private getRestartLink = () =>
-    this.addOption(this.customization.restartOptionText, this.restartGame, idRunnerOptionRestart);
+  private getRestartLink = () => {
+    return this.addOption(
+      (this.props as CombinedProps).authorStorySettings.authorStoryStrings.restartLinkText || "restart", // TODO: localize
+      this.restartGame,
+      idRunnerOptionRestart
+    );
+  };
 
   constructor(props: CombinedProps) {
     super(props);
-
     this.refreshInterpreter();
+  }
 
-    if (this.props.showErrors) {
-      this.customization.showErrors = this.props.showErrors;
+  public shouldComponentUpdate(nextProps: Readonly<StoryInterpreterOwnProps>) {
+    const props = this.props as CombinedProps;
+    const newProps = nextProps as CombinedProps;
+
+    // Update random if necessary.
+    if (!random || newProps.authorStorySettings.authorStoryRunnerOptions.randomSeed !== random.seed) {
+      random = new Random(newProps.authorStorySettings.authorStoryRunnerOptions.randomSeed);
     }
 
-    if (this.props.random) {
-      this.customization.random = this.props.random;
+    // Recompute cached versions of all components.
+    if (
+      props.authorStorySettings !== newProps.authorStorySettings ||
+      props.currentStorySettings !== newProps.currentStorySettings ||
+      props.theme !== newProps.theme
+    ) {
+      this.contentCached = this.content.map((node: InterpreterNode) => node(newProps));
+      this.logCached = this.log.map((node: InterpreterNode) => node(newProps));
+      this.optionsCached = this.options.map((node: InterpreterNode) => node(newProps));
     }
+
+    return true;
   }
 
   /** Creates and returns a text element styled to represent the player's input. */
   public addInput(text: string) {
-    return (
-      <p key={`${idRunnerInputElement}-${uniqueKeyCounter++}`} style={this.customization.styles.styleInput}>
+    return (props: CombinedProps) => (
+      <p
+        key={`${idRunnerInputElement}-${uniqueKeyCounter++}`}
+        style={this.getTextStyle(
+          props,
+          !props.debugging ? props.playerStorySettings.playerStoryInputStyles : {},
+          {}, // can't pass styles
+          props.authorStorySettings.authorStoryInputStyles
+        )}
+      >
         {text}
       </p>
     );
@@ -206,43 +202,78 @@ export class StoryInterpreterC extends React.Component<StoryInterpreterOwnProps>
    * provided, it indicates the fork to go to. Passing a function can execute custom code instead.
    */
   public addOption(text: string, forkNameOrAction: string | (() => void), key?: string) {
-    const themeStyle = this.customization.styles;
+    const style = Object.assign({}, this.currentOptionStyles);
+
+    const combinedProps = this.props as CombinedProps;
     const linkAction =
       typeof forkNameOrAction === "function"
         ? forkNameOrAction
         : () => {
-            if (this.customization.preserveOldOutput) {
+            // When clicking the option, push player input to content if at least one item is logged.
+            if (
+              !combinedProps.authorStorySettings.authorStoryRunnerOptions.hideLog &&
+              (!combinedProps.authorStorySettings.authorStoryRunnerOptions.logLimit ||
+                combinedProps.authorStorySettings.authorStoryRunnerOptions.logLimit > 0)
+            ) {
               this.content.push(this.addInput(text));
             }
 
+            // Go to the fork (moves old content to logs as a side effect).
             this.setFork(forkNameOrAction);
           };
 
-    return (
-      <ActionButton
-        key={key ? key : `${idRunnerOptionElement}-${uniqueKeyCounter++}`}
-        onClick={linkAction}
-        styles={{
-          root: {
-            ...(themeStyle.styleOptions as object),
-            display: "block",
-            height: "32px",
-          },
-          rootFocused: { ...(themeStyle.styleOptionsHighlight as object) },
-          rootHovered: { ...(themeStyle.styleOptionsHighlight as object) },
-        }}
-        text={text}
-      />
-    );
+    return (props: CombinedProps) => {
+      const styleOptions = this.getTextStyle(
+        props,
+        !props.debugging ? props.playerStorySettings.playerStoryOptionStyles : {},
+        style,
+        props.authorStorySettings.authorStoryOptionStyles
+      );
+
+      const styleOptionsHighlight = this.getTextStyle(
+        props,
+        !props.debugging ? props.playerStorySettings.playerStoryOptionHighlightStyles : {},
+        style,
+        props.authorStorySettings.authorStoryOptionHighlightStyles
+      );
+
+      return (
+        <ActionButton
+          key={key || `${idRunnerOptionElement}-${uniqueKeyCounter++}`}
+          onClick={linkAction}
+          styles={{
+            root: {
+              ...(styleOptions as object),
+              display: "block",
+              height: "32px",
+            },
+            rootFocused: { ...(styleOptionsHighlight as object) },
+            rootHovered: { ...(styleOptionsHighlight as object) },
+          }}
+          text={text}
+        />
+      );
+    };
   }
 
   /** Creates and returns a text element styled as output text. */
   public addOutput(text: string) {
-    return (
-      <p key={`${idRunnerOutputElement}-${uniqueKeyCounter++}`} style={this.customization.styles.styleOutput}>
-        {text}
-      </p>
-    );
+    const style = Object.assign({}, this.currentOutputStyles);
+
+    return (props: CombinedProps) => {
+      const styleOutput = this.getTextStyle(
+        props,
+        !props.debugging ? props.playerStorySettings.playerStoryOptionStyles : {},
+        style,
+        props.authorStorySettings.authorStoryOptionStyles
+      );
+
+      return (
+        <span key={`${idRunnerOutputElement}-${uniqueKeyCounter++}`} style={styleOutput}>
+          {text}
+        </span>
+      );
+    };
   }
 
   /** Loads the current progress from local storage if possible. */
@@ -298,6 +329,8 @@ export class StoryInterpreterC extends React.Component<StoryInterpreterOwnProps>
 
   /** Parses a special set of options at the top of the file. */
   public processHeaderOptions(text: string) {
+    const combinedProps = this.props as CombinedProps;
+
     // Clears all old preferences.
     this.refreshInterpreter();
 
@@ -318,11 +351,15 @@ export class StoryInterpreterC extends React.Component<StoryInterpreterOwnProps>
       input = input.trim();
 
       if (line.startsWith("link-style-text")) {
-        this.customization.discreteInlineLinks = true;
-      } else if (line.startsWith("option-default-text")) {
-        this.customization.restartOptionText = input;
+        combinedProps.dispatchSetTempStoryRunnerOptions({
+          ...combinedProps.currentStorySettings.currentRunnerSettings,
+          discreteInlineLinks: true,
+        });
       } else if (line.startsWith("option-default-disable")) {
-        this.customization.restartOptionDisabled = true;
+        combinedProps.dispatchSetTempStoryRunnerOptions({
+          ...combinedProps.currentStorySettings.currentRunnerSettings,
+          hideRestartLink: true,
+        });
       } else if (
         line.startsWith("option-color") ||
         line.startsWith("option-hover-color") ||
@@ -347,11 +384,44 @@ export class StoryInterpreterC extends React.Component<StoryInterpreterOwnProps>
         }
 
         if (line.startsWith("option-color")) {
-          this.customization.styles.styleOptions.color = color;
+          this.currentOptionStyles.colorDark = color;
+          this.currentOptionStyles.colorLight = color;
+        } else if (line.startsWith("option-color-light")) {
+          this.currentOptionStyles.colorLight = color;
+        } else if (line.startsWith("option-color-dark")) {
+          this.currentOptionStyles.colorDark = color;
         } else if (line.startsWith("option-hover-color")) {
-          this.customization.styles.styleOptionsHighlight.color = color;
+          this.currentOptionHighlightStyles.colorDark = color;
+          this.currentOptionHighlightStyles.colorLight = color;
+        } else if (line.startsWith("option-hover-color-light")) {
+          this.currentOptionHighlightStyles.colorLight = color;
+        } else if (line.startsWith("option-hover-color-dark")) {
+          this.currentOptionHighlightStyles.colorDark = color;
         } else if (line.startsWith("background-color")) {
-          this.customization.styles.styleRunner.backgroundColor = color;
+          combinedProps.dispatchSetAuthorStoryRunnerStyles({
+            background: {
+              ...combinedProps.authorStorySettings.authorStoryRunnerStyles,
+              colorDark: color,
+              colorLight: color,
+              type: "plain",
+            },
+          });
+        } else if (line.startsWith("background-color-light")) {
+          combinedProps.dispatchSetAuthorStoryRunnerStyles({
+            background: {
+              ...combinedProps.authorStorySettings.authorStoryRunnerStyles,
+              colorLight: color,
+              type: "plain",
+            },
+          });
+        } else if (line.startsWith("background-color-dark")) {
+          combinedProps.dispatchSetAuthorStoryRunnerStyles({
+            background: {
+              ...combinedProps.authorStorySettings.authorStoryRunnerStyles,
+              colorDark: color,
+              type: "plain",
+            },
+          });
         }
       } else if (line.startsWith("output-font-size") || line.startsWith("option-font-size")) {
         if (!numberRegex.test(input)) {
@@ -367,14 +437,14 @@ export class StoryInterpreterC extends React.Component<StoryInterpreterOwnProps>
         }
 
         if (line.startsWith("output-font-size")) {
-          this.customization.styles.styleOutput.fontSize = number;
+          this.currentOutputStyles.fontSize = number.toString();
         } else if (line.startsWith("option-font-size")) {
-          this.customization.styles.styleOutput.fontSize = number;
+          this.currentOptionStyles.fontSize = number.toString();
         }
       } else if (line.startsWith("option-font")) {
-        this.customization.styles.styleOptions.fontFamily = input + "; " + fallbackFontStack;
+        this.currentOptionStyles.font = `${input}; ${fallbackFontStack}`;
       } else if (line.startsWith("output-font")) {
-        this.customization.styles.styleOutput.fontFamily = input + "; " + fallbackFontStack;
+        this.currentOutputStyles.font = `${input}; ${fallbackFontStack}`;
       }
     }
   }
@@ -389,24 +459,28 @@ export class StoryInterpreterC extends React.Component<StoryInterpreterOwnProps>
   public render(): React.ReactNode {
     this.refreshInterpreterGuiStyles();
 
+    const combinedProps = this.props as CombinedProps;
+
     const restartOption =
-      this.options.length === 0 && !this.customization.restartOptionDisabled ? this.getRestartLink() : undefined;
+      this.options.length === 0 && !combinedProps.authorStorySettings.authorStoryRunnerOptions.hideRestartLink
+        ? [this.getRestartLink() as InterpreterNode]
+        : [];
 
     const allOutput = [
       <div key={idRunnerLog} id={idRunnerLog}>
-        {this.log}
+        {this.logCached}
       </div>,
       <div key={idRunnerContent} id={idRunnerContent}>
-        {this.content}
+        {this.contentCached}
       </div>,
       <div key={idRunnerOptions} id={idRunnerOptions}>
-        {this.options}
+        {this.optionsCached}
         {restartOption}
       </div>,
     ];
 
     const errorMessage =
-      this.customization.showErrors && this.errorMessage !== "" ? (
+      this.props.debugging && this.errorMessage !== "" ? (
         <MessageBar messageBarType={MessageBarType.error}>{this.errorMessage}</MessageBar>
       ) : undefined;
 
@@ -423,11 +497,13 @@ export class StoryInterpreterC extends React.Component<StoryInterpreterOwnProps>
     ) : undefined;
 
     return (
-      <div className={runnerWrapperStyle}>
-        <div className={runnerOutputWrapperStyle}>{allOutput}</div>
-        {errorMessage}
-        {textbox}
-      </div>
+      <>
+        <div className={runnerWrapperStyle}>
+          <div className={runnerOutputWrapperStyle}>{allOutput}</div>
+          {errorMessage}
+          {textbox}
+        </div>
+      </>
     );
   }
 
@@ -478,6 +554,79 @@ export class StoryInterpreterC extends React.Component<StoryInterpreterOwnProps>
     this.loadFork();
   }
 
+  /**
+   * Applies text styles to determine font family, size, bold/italic/underline, and color. Players can set their own
+   * style overrides (playerStyle). The author can set styles within the game that deviate from the normal styling
+   * (storyStyle), and set a global default style for the story (authorStyle). When editing a story, playerStyle should
+   * be left empty. PlayerStyle overrides storyStyle, which overrides authorStyle. Overrides work per attribute, and
+   * fall down to the next style if not met, or a natural default if none are met.
+   *
+   * Light colors are used in lightMode and dark colors in darkMode, as defined by the theming.
+   *
+   * @param playerStyle Styles that a player has set to override all styles in stories they read, if set.
+   * @param storyStyle Specific one-off styling within the story.
+   * @param authorStyle Styles that an author has set as the default text styling.
+   */
+  private getTextStyle = (
+    props: CombinedProps,
+    playerStyle: ITextStyle,
+    storyStyle: ITextStyle,
+    authorStyle: ITextStyle
+  ): React.CSSProperties => {
+    const color =
+      props.theme.localizedName === themes.light.localizedName
+        ? playerStyle.colorLight ||
+          storyStyle.colorLight ||
+          authorStyle.colorLight ||
+          themes.light.theme.semanticColors.bodyText
+        : playerStyle.colorDark ||
+          storyStyle.colorDark ||
+          authorStyle.colorDark ||
+          themes.dark.theme.semanticColors.bodyText;
+
+    const fontFamily = playerStyle.font || storyStyle.font || authorStyle.font || fallbackFontStack;
+
+    const fontSize =
+      `${playerStyle.fontSize} rem` || `${storyStyle.fontSize} rem` || `${authorStyle.fontSize} rem` || "1 rem";
+
+    let fontStyle: "italic" | "normal" = "normal";
+    let fontWeight: "bold" | "normal" = "normal";
+    let textDecoration: "underline" | "inherit" = "inherit";
+
+    if (playerStyle.fontStyle) {
+      fontStyle = playerStyle.fontStyle.includes("i") ? "italic" : "normal";
+    } else if (storyStyle.fontStyle) {
+      fontStyle = storyStyle.fontStyle.includes("i") ? "italic" : "normal";
+    } else if (authorStyle.fontStyle) {
+      fontStyle = authorStyle.fontStyle.includes("i") ? "italic" : "normal";
+    }
+
+    if (playerStyle.fontStyle) {
+      fontWeight = playerStyle.fontStyle.includes("b") ? "bold" : "normal";
+    } else if (storyStyle.fontStyle) {
+      fontWeight = storyStyle.fontStyle.includes("b") ? "bold" : "normal";
+    } else if (authorStyle.fontStyle) {
+      fontWeight = authorStyle.fontStyle.includes("b") ? "bold" : "normal";
+    }
+
+    if (playerStyle.fontStyle) {
+      textDecoration = playerStyle.fontStyle.includes("u") ? "underline" : "inherit";
+    } else if (storyStyle.fontStyle) {
+      textDecoration = storyStyle.fontStyle.includes("u") ? "underline" : "inherit";
+    } else if (authorStyle.fontStyle) {
+      textDecoration = authorStyle.fontStyle.includes("u") ? "underline" : "inherit";
+    }
+
+    return {
+      color,
+      fontFamily,
+      fontSize,
+      fontStyle,
+      fontWeight,
+      textDecoration,
+    };
+  };
+
   /** Escapes the given text for all supported escape sequences. */
   private escapeText(text: string, matchBraces: boolean) {
     if (matchBraces) {
@@ -512,6 +661,15 @@ export class StoryInterpreterC extends React.Component<StoryInterpreterOwnProps>
       return str;
     });
   }
+
+  /** Renders the content. */
+  private onRenderContent = (item?: InterpreterNode): JSX.Element => {
+    if (!item) {
+      return <></>;
+    }
+
+    return item(this.props as CombinedProps);
+  };
 
   /** Handles submission of text in the textbox. */
   private onTextboxKeyPress = (ev: React.KeyboardEvent<HTMLInputElement>) => {
@@ -550,6 +708,8 @@ export class StoryInterpreterC extends React.Component<StoryInterpreterOwnProps>
    * parsed the next time input is submitted through the textbox.
    */
   private processIf(node: StoryParseNode, textboxText: string): boolean {
+    const combinedProps = this.props as CombinedProps;
+
     // If there are no conditions, consider it met.
     if (node.condition.trim() === "") {
       return true;
@@ -662,7 +822,11 @@ export class StoryInterpreterC extends React.Component<StoryInterpreterOwnProps>
             }
 
             // If still executing, conditions are met.
-            if (this.customization.preserveOldOutput) {
+            if (
+              !combinedProps.authorStorySettings.authorStoryRunnerOptions.hideLog &&
+              (!combinedProps.authorStorySettings.authorStoryRunnerOptions.logLimit ||
+                combinedProps.authorStorySettings.authorStoryRunnerOptions.logLimit > 0)
+            ) {
               this.content.push(this.addInput(text));
             }
 
@@ -704,7 +868,11 @@ export class StoryInterpreterC extends React.Component<StoryInterpreterOwnProps>
             text = text.toLowerCase().trim();
 
             if ((words[1] === "is" && text === query) || (words[1] === "!is" && text !== query)) {
-              if (this.customization.preserveOldOutput) {
+              if (
+                !combinedProps.authorStorySettings.authorStoryRunnerOptions.hideLog &&
+                (!combinedProps.authorStorySettings.authorStoryRunnerOptions.logLimit ||
+                  combinedProps.authorStorySettings.authorStoryRunnerOptions.logLimit > 0)
+              ) {
                 this.content.push(this.addInput(text));
               }
 
@@ -750,7 +918,11 @@ export class StoryInterpreterC extends React.Component<StoryInterpreterOwnProps>
             }
 
             // If still executing, conditions are met.
-            if (this.customization.preserveOldOutput) {
+            if (
+              !combinedProps.authorStorySettings.authorStoryRunnerOptions.hideLog &&
+              (!combinedProps.authorStorySettings.authorStoryRunnerOptions.logLimit ||
+                combinedProps.authorStorySettings.authorStoryRunnerOptions.logLimit > 0)
+            ) {
               this.content.push(this.addInput(text));
             }
 
@@ -947,16 +1119,14 @@ export class StoryInterpreterC extends React.Component<StoryInterpreterOwnProps>
           continue;
         }
 
-        const fontStyle = this.customization.styles.styleOutput.fontStyle;
-        const fontWeight = this.customization.styles.styleOutput.fontWeight;
-
         if (output.includes("***}")) {
-          this.customization.styles.styleOutput.fontStyle = "italic";
-          this.customization.styles.styleOutput.fontWeight = 600;
+          this.currentOutputStyles.fontStyle = "ib";
         } else if (output.includes("**}")) {
-          this.customization.styles.styleOutput.fontWeight = 600;
+          this.currentOutputStyles.fontStyle = "b";
         } else if (output.includes("*}")) {
-          this.customization.styles.styleOutput.fontStyle = "italic";
+          this.currentOutputStyles.fontStyle = "i";
+        } else {
+          this.currentOutputStyles.fontStyle = undefined;
         }
 
         // create output
@@ -967,9 +1137,6 @@ export class StoryInterpreterC extends React.Component<StoryInterpreterOwnProps>
 
         // Generates the text
         this.content.push(this.addOutput(output));
-
-        this.customization.styles.styleOutput.fontStyle = fontStyle;
-        this.customization.styles.styleOutput.fontWeight = fontWeight;
 
         // Removes the processed text.
         textLeft = textLeft.substring(0, lbPos) + textLeft.substring(rbPos + 1, textLeft.length);
@@ -1001,7 +1168,7 @@ export class StoryInterpreterC extends React.Component<StoryInterpreterOwnProps>
             if (tokens[0] instanceof TokenNum) {
               const n0 = tokens[0] as TokenNum;
 
-              return new TokenNum(this.customization.random.nextNumber() * n0.value + 1);
+              return new TokenNum(random!.nextNumber() * n0.value + 1);
             }
 
             return null;
@@ -1261,8 +1428,9 @@ export class StoryInterpreterC extends React.Component<StoryInterpreterOwnProps>
               line +
               "', color must be given in hex format using 3 or 6 digits. For example, f00 or 8800f0."
           );
-        } else if (color.length === 3) {
-          this.customization.styles.styleOutput.color = color.substring(0, 3);
+        } else {
+          this.currentOutputStyles.colorDark = color;
+          this.currentOutputStyles.colorLight = color;
         }
 
         // Deletes the line just processed.
@@ -1292,15 +1460,9 @@ export class StoryInterpreterC extends React.Component<StoryInterpreterOwnProps>
   private refreshInterpreter() {
     this.actions = [];
     this.content = [];
-    this.customization = {
-      discreteInlineLinks: this.defaultCustomization.discreteInlineLinks,
-      preserveOldOutput: this.defaultCustomization.preserveOldOutput,
-      random: this.defaultCustomization.random,
-      restartOptionDisabled: this.defaultCustomization.restartOptionDisabled,
-      restartOptionText: this.defaultCustomization.restartOptionText,
-      showErrors: this.defaultCustomization.showErrors,
-      styles: this.customization.styles,
-    };
+    this.currentOptionStyles = {};
+    this.currentOptionHighlightStyles = {};
+    this.currentOutputStyles = {};
     this.errorMessage = "";
     this.fork = "";
     this.log = [];
@@ -1314,24 +1476,27 @@ export class StoryInterpreterC extends React.Component<StoryInterpreterOwnProps>
 
   /** Initializes or resets the gui styles. */
   private refreshInterpreterGuiStyles() {
-    const themeStyles =
-      (this.props as CombinedProps).theme.localizedName === themes.light.localizedName
-        ? this.defaultLightThemeStyle
-        : this.defaultDarkThemeStyle;
-
-    this.customization.styles = {
-      styleInput: { ...themeStyles.styleInput },
-      styleOptions: { ...themeStyles.styleOptions },
-      styleOptionsHighlight: { ...themeStyles.styleOptionsHighlight },
-      styleOutput: { ...themeStyles.styleOutput },
-      styleRunner: { ...themeStyles.styleRunner },
-    };
+    const combinedProps = this.props as CombinedProps;
 
     // Updates the background color of the runner.
     const runner = document.getElementById(idRunnerWrapper);
 
-    if (runner && this.customization.styles.styleRunner.backgroundColor) {
-      runner.style["backgroundColor"] = this.customization.styles.styleRunner.backgroundColor;
+    if (runner) {
+      if (combinedProps.playerStorySettings.playerStoryRunnerStyles.background.type === "plain") {
+        runner.style["backgroundColor"] =
+          combinedProps.theme.localizedName === themes.light.localizedName
+            ? combinedProps.playerStorySettings.playerStoryRunnerStyles.background.colorLight ||
+              themes.light.theme.semanticColors.bodyBackground
+            : combinedProps.playerStorySettings.playerStoryRunnerStyles.background.colorDark ||
+              themes.dark.theme.semanticColors.bodyBackground;
+      } else if (combinedProps.authorStorySettings.authorStoryRunnerStyles.background.type === "plain") {
+        runner.style["backgroundColor"] =
+          combinedProps.theme.localizedName === themes.light.localizedName
+            ? combinedProps.authorStorySettings.authorStoryRunnerStyles.background.colorLight ||
+              themes.light.theme.semanticColors.bodyBackground
+            : combinedProps.authorStorySettings.authorStoryRunnerStyles.background.colorDark ||
+              themes.dark.theme.semanticColors.bodyBackground;
+      }
     }
   }
 
@@ -1345,7 +1510,12 @@ export class StoryInterpreterC extends React.Component<StoryInterpreterOwnProps>
 
   /** Empties the log or updates it, depending on interpreter options. */
   private updateLog() {
-    if (!this.customization.preserveOldOutput) {
+    const combinedProps = this.props as CombinedProps;
+
+    if (
+      combinedProps.authorStorySettings.authorStoryRunnerOptions.hideLog ||
+      combinedProps.authorStorySettings.authorStoryRunnerOptions.logLimit === 0
+    ) {
       this.log = [];
     } else {
       this.log.push(...this.content);

--- a/src/parse-story/storyParser.ts
+++ b/src/parse-story/storyParser.ts
@@ -51,7 +51,7 @@ function isOutput(text: string, index: number) {
   return true;
 }
 
-/** Returns a dictionary containing a node tree for each fork. */
+/** Updates the passed-in interpreter with a node tree for each fork. */
 export function parseStory(story: string, interpreter: React.RefObject<StoryInterpreterC>, forkToLoad?: string) {
   const entries: { [key: string]: string } = {};
   const parsed: { [key: string]: StoryParseNode } = {};

--- a/src/store.ts
+++ b/src/store.ts
@@ -5,6 +5,7 @@ import { IPersistenceState, persistence } from "./common/storage/persistence.red
 import { IViewEditState, viewEdit } from "./common/redux/viewedit.reducers";
 import { IAuthorStorySettingsState, authorStorySettings } from "./common/redux/authorStorySettings.reducers";
 import { IPlayerStorySettingsState, playerStorySettings } from "./common/redux/playerStorySettings.reducers";
+import { ICurrentRunnerSettingsState, currentRunnerSettings } from "./common/redux/currentRunnerSettings.reducers";
 
 /** All reducers. */
 export interface IRootState {
@@ -12,6 +13,7 @@ export interface IRootState {
   settings: ISettingState;
   viewEdit: IViewEditState;
   authorStorySettings: IAuthorStorySettingsState;
+  currentRunnerSettings: ICurrentRunnerSettingsState;
   playerStorySettings: IPlayerStorySettingsState;
 }
 
@@ -20,6 +22,7 @@ const rootReducer = combineReducers({
   settings,
   viewEdit,
   authorStorySettings,
+  currentRunnerSettings,
   playerStorySettings,
 });
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -3,18 +3,24 @@ import thunk from "redux-thunk";
 import { ISettingState, settings } from "./common/settings/settings.reducers";
 import { IPersistenceState, persistence } from "./common/storage/persistence.reducers";
 import { IViewEditState, viewEdit } from "./common/redux/viewedit.reducers";
+import { IAuthorStorySettingsState, authorStorySettings } from "./common/redux/authorStorySettings.reducers";
+import { IPlayerStorySettingsState, playerStorySettings } from "./common/redux/playerStorySettings.reducers";
 
 /** All reducers. */
 export interface IRootState {
   persistence: IPersistenceState;
   settings: ISettingState;
   viewEdit: IViewEditState;
+  authorStorySettings: IAuthorStorySettingsState;
+  playerStorySettings: IPlayerStorySettingsState;
 }
 
 const rootReducer = combineReducers({
   persistence,
   settings,
   viewEdit,
+  authorStorySettings,
+  playerStorySettings,
 });
 
 /** Provides global access to the static Redux store. */


### PR DESCRIPTION
Light and dark mode themes are deeply supported for customization by both author and player:
- Author styles have least precedence and are applied to the whole story
- Current/temp styles have medium precedence and override styling for sections in the story
- Player styles have greatest precedence and override both the others

The runner and its contents now respond correctly in realtime to the theme being changed.

Styles and a number of settings expecting support, which govern things like whether to show logs and autosaving behavior, have been added in reducers. Only IFontStyle for options, highlighted options, output and input logs is implemented.

Players can now click play to restart the game, even without changing any of their code.